### PR TITLE
add CREATE_NO_WINDOW for gui mode

### DIFF
--- a/src/popen.rs
+++ b/src/popen.rs
@@ -917,7 +917,7 @@ mod os {
                 = win32::CreateProcess(executable.as_ref().map(OsString::as_ref),
                                        &cmdline, &env_block,
                                        &config.cwd.as_ref().map(|os| &os[..]),
-                                       true, 0,
+                                       true, win32::CREATE_NO_WINDOW,
                                        raw(&child_stdin),
                                        raw(&child_stdout),
                                        raw(&child_stderr),

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -47,6 +47,7 @@ impl FromRawHandle for Handle {
 
 pub const HANDLE_FLAG_INHERIT: u32 = 1;
 pub const STARTF_USESTDHANDLES: DWORD = winapi::winbase::STARTF_USESTDHANDLES;
+pub const CREATE_NO_WINDOW: DWORD = winapi::winbase::CREATE_NO_WINDOW;
 
 fn check(status: BOOL) -> Result<()> {
     if status != 0 {


### PR DESCRIPTION
//it will popup a black console windows in windows
#![windows_subsystem = "windows"] 
extern crate subprocess;

use subprocess::{Exec,Redirection};
use std::io::{BufReader, BufRead};
use std::io::prelude::*;
use std::fs::File;

fn main() {
    let out = Exec::cmd("dir")
	.stdout(Redirection::Pipe)
	.capture().unwrap()
  	.stdout_str();
	println!("{}",out);
	let mut file = File::create("out.txt").unwrap();
	file.write_all(&out.into_bytes()).unwrap();
}
