### PR TITLE
Add `Exec.to_string()` and `Pipeline.to_string()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.idea/

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -21,6 +21,7 @@ mod exec {
     use std::fs::{File, OpenOptions};
     use std::ops::BitOr;
     use std::path::Path;
+    use std::fmt;
 
     use popen::{PopenConfig, Popen, Redirection, Result as PopenResult};
     use os_common::ExitStatus;
@@ -443,6 +444,16 @@ mod exec {
         }
     }
 
+    impl fmt::Display for Exec {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            let mut args = Vec::new();
+            for a in &self.args {
+                args.push(format!(r#""{}""#, a.to_str().unwrap_or("")));
+            }
+            write!(f, "{} {}", self.command.to_str().unwrap_or(""), args.join(" "))
+        }
+    }
+
     #[derive(Debug)]
     struct ReadOutAdapter(Popen);
 
@@ -597,6 +608,7 @@ mod pipeline {
     use std::io::{Result as IoResult, Read, Write};
     use std::ops::BitOr;
     use std::fs::File;
+    use std::fmt;
 
     use popen::{Popen, Redirection, Result as PopenResult};
     use communicate;
@@ -866,6 +878,16 @@ mod pipeline {
             self.cmds.extend(rhs.cmds);
             self.stdout = rhs.stdout;
             self
+        }
+    }
+
+    impl fmt::Display for Pipeline {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            let mut args = Vec::new();
+            for cmd in &self.cmds {
+                args.push(cmd.to_string());
+            }
+            write!(f, "{}", args.join(" | "))
         }
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -448,7 +448,16 @@ mod exec {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             let mut args = Vec::new();
             for a in &self.args {
-                args.push(format!(r#""{}""#, a.to_str().unwrap_or("")));
+                let arg_as_str = a.to_str().unwrap_or("");
+                let contains_quote = arg_as_str.contains("'");
+                let contains_metachar = arg_as_str.chars().any(|c| c.is_control() || c.is_whitespace());
+                if contains_quote || contains_metachar  {
+                    args.push(
+                        format!("'{}'", arg_as_str.replace("'", r#"'\''"#))
+                    )
+                } else {
+                    args.push(arg_as_str.to_string());
+                }
             }
             write!(f, "{} {}", self.command.to_str().unwrap_or(""), args.join(" "))
         }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -448,10 +448,9 @@ mod exec {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             let mut args = Vec::new();
             for a in &self.args {
-                let arg_as_str = a.to_str().unwrap_or("");
-                let contains_quote = arg_as_str.contains("'");
-                let contains_metachar = arg_as_str.chars().any(|c| c.is_control() || c.is_whitespace());
-                if contains_quote || contains_metachar  {
+                let arg_as_str = a.to_string_lossy();
+                let needs_quote = arg_as_str.chars().any(|c| !c.is_ascii_alphanumeric());
+                if needs_quote  {
                     args.push(
                         format!("'{}'", arg_as_str.replace("'", r#"'\''"#))
                     )

--- a/src/tests/builder.rs
+++ b/src/tests/builder.rs
@@ -227,9 +227,10 @@ fn exec_to_string() {
         .arg("arg1")
         .arg("don't")
         .arg("arg3 arg4")
+        .arg("?")
         .arg(" ") // regular space
         .arg(""); // U+009C, STRING TERMINATOR
-    assert_eq!(cmd.to_string(), r#"sh arg1 'don'\''t' 'arg3 arg4' ' ' ''"#)
+    assert_eq!(cmd.to_string(), r#"sh arg1 'don'\''t' 'arg3 arg4' '?' ' ' ''"#)
 }
 
 #[test]
@@ -237,5 +238,5 @@ fn pipeline_to_string() {
     let pipeline = {
         Exec::cmd("echo").arg("foo") | Exec::cmd("wc").arg("-l")
     };
-    assert_eq!(pipeline.to_string(), "echo foo | wc -l")
+    assert_eq!(pipeline.to_string(), "echo foo | wc '-l'")
 }

--- a/src/tests/builder.rs
+++ b/src/tests/builder.rs
@@ -223,8 +223,13 @@ fn env_inherit_set() {
 
 #[test]
 fn exec_to_string() {
-    let cmd = Exec::cmd("sh").arg("arg1").arg("arg2").arg("arg3 arg4");
-    assert_eq!(cmd.to_string(), r#"sh "arg1" "arg2" "arg3 arg4""#)
+    let cmd = Exec::cmd("sh")
+        .arg("arg1")
+        .arg("don't")
+        .arg("arg3 arg4")
+        .arg(" ") // regular space
+        .arg(""); // U+009C, STRING TERMINATOR
+    assert_eq!(cmd.to_string(), r#"sh arg1 'don'\''t' 'arg3 arg4' ' ' ''"#)
 }
 
 #[test]

--- a/src/tests/builder.rs
+++ b/src/tests/builder.rs
@@ -220,3 +220,17 @@ fn env_inherit_set() {
             .join().unwrap().success());
     env::remove_var(varname);
 }
+
+#[test]
+fn exec_to_string() {
+    let cmd = Exec::cmd("sh").arg("arg1").arg("arg2").arg("arg3 arg4");
+    assert_eq!(cmd.to_string(), r#"sh "arg1" "arg2" "arg3 arg4""#)
+}
+
+#[test]
+fn pipeline_to_string() {
+    let pipeline = {
+        Exec::cmd("echo").arg("foo") | Exec::cmd("wc").arg("-l")
+    };
+    assert_eq!(pipeline.to_string(), "echo foo | wc -l")
+}


### PR DESCRIPTION
The purpose of this PR is to have ready to use display functions for `Exec` & `Pipeline`.

Happy to discuss the output of the `fmt` functions.