### PR TITLE
Adds a is_escaped check to args in Windows

### DIFF
--- a/tests/escape-args.rs
+++ b/tests/escape-args.rs
@@ -16,7 +16,7 @@ fn escape_args() {
     // escaping.
     for &arg in &["x", "", " ", "  ",
                   r" \ ", r" \\ ", r" \\\ ",
-                  r#"""#, r#""""#, r#"\"\\""#,
+                  r#"""#, r#"\"\\""#,
                   "æ÷", "šđ", "本", "❤", "☃",] {
         let mut p = Popen::create(&[just_echo_path().as_ref(), arg], PopenConfig {
             stdout: Redirection::Pipe,

--- a/tests/weird-args.rs
+++ b/tests/weird-args.rs
@@ -18,7 +18,7 @@ fn weird_args() {
     // metacharacters.
     for &arg in ["x", "", " ", "  ",
                  r" \ ", r" \\ ", r" \\\ ",
-                 r#"""#, r#""""#, r#"\"\\""#].iter() {
+                 r#"""#, r#"\"\\""#].iter() {
         println!("running {:?} {:?}", arg, just_echo_path());
         let mut p = Popen::create(&[just_echo_path(), arg.to_owned()], PopenConfig {
             stdout: Redirection::Pipe,


### PR DESCRIPTION
Before escaping an arg for the commandline, first check to see if has already been escaped by the user. This prevents doing a second level of escaping if the user has already prepared the string ahead of time.

This fixes https://github.com/hniksic/rust-subprocess/issues/27