### PR TITLE
Remove deprecated error.description() method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subprocess"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Hrvoje Nikšić <hniksic@gmail.com>"]
 readme = "README.md"
 keywords = ["execute", "process", "command", "redirect", "pipe"]

--- a/src/communicate.rs
+++ b/src/communicate.rs
@@ -577,10 +577,6 @@ impl CommunicateError {
 }
 
 impl Error for CommunicateError {
-    fn description(&self) -> &str {
-        self.error.description()
-    }
-
     fn cause(&self) -> Option<&dyn Error> {
         self.error.source()
     }

--- a/src/popen.rs
+++ b/src/popen.rs
@@ -1269,13 +1269,6 @@ impl From<communicate::CommunicateError> for PopenError {
 }
 
 impl Error for PopenError {
-    fn description(&self) -> &str {
-        match *self {
-            PopenError::IoError(ref err) => err.description(),
-            PopenError::LogicError(description) => description,
-        }
-    }
-
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
             PopenError::IoError(ref err) => Some(err as &dyn Error),


### PR DESCRIPTION
Fixed warning messages:

```
warning: use of deprecated item 'std::error::Error::description': use the Display impl or to_string()
   --> src/communicate.rs:581:20
    |
581 |         self.error.description()
    |                    ^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: use of deprecated item 'std::error::Error::description': use the Display impl or to_string()
    --> src/popen.rs:1274:49
     |
1274 |             PopenError::IoError(ref err) => err.description(),
     |                                                 ^^^^^^^^^^^

```