### PR TITLE
Update docs for limit_time

### DIFF
--- a/src/communicate.rs
+++ b/src/communicate.rs
@@ -527,6 +527,9 @@ impl Communicator {
 
     /// Limit the amount of time the next `read()` will spend reading from the
     /// subprocess.
+    ///
+    /// Note: On Windows, zero duration may result in no output from ever being
+    /// read.
     pub fn limit_time(mut self, time: Duration) -> Communicator {
         self.time_limit = Some(time);
         self


### PR DESCRIPTION
Thanks to Kobata from `#windows-dev` on Discord for figuring this out.

I was previously setting `.limit_time(Duration::from_millis(0))` with the intention of immediately returning when there's no output ready. This seems to work fine on Linux, Mac, and even wine, but on a few different Windows machines, `read()` never returned anything. Changing this to 1ms fixed things.

This may be something that should be fixed in the implementation; I haven't dug in. But at the very least, mentioning it in the docs should save somebody else from making the same mistake.