### PR TITLE
Increase libc version requirement to match codebase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ module, with Rust-specific extensions.
 edition = "2018"
 
 [dependencies]
-libc = "0.2.66"
+libc = "0.2.78"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.8", features = ["std", "handleapi", "namedpipeapi", "processenv", "synchapi", "winerror", "processthreadsapi", "winbase"] }


### PR DESCRIPTION
https://github.com/hniksic/rust-subprocess/commit/14cfe4599c121919ce8fb7c2a07991b6351bbbe5 appears to have started relying on `libc` changes introduced in version 0.2.78. As a result `subprocess` doesn't actually build with the version of `libc` specified in `Cargo.toml`. This PR increases the required version to match the expectations of the `subprocess` code.