### PR TITLE
Implement pipeline constructor from exec iterator

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -831,11 +831,11 @@ mod pipeline {
         /// ```
         /// Errors:
         ///   - Panics when the passed iterator contains less than two (2) items.
-        pub fn from_exec_iter<I>(iterator: I) -> Pipeline
+        pub fn from_exec_iter<I>(iterable: I) -> Pipeline
         where
             I: IntoIterator<Item = Exec>,
         {
-            let cmds: Vec<_> = iterator.into_iter().collect();
+            let cmds: Vec<_> = iterable.into_iter().collect();
 
             if cmds.len() < 2 {
                 panic!("iterator needs to contain at least two (2) elements")

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -802,7 +802,23 @@ mod pipeline {
             }
         }
 
-        /// Creates a new pipeline from a list of commands.
+        /// Creates a new pipeline from a list of commands. Useful if
+        /// a pipeline should be created dynamically.
+        ///
+        /// Example:
+        /// ```rust
+        /// use subprocess::Exec;
+        ///
+        /// let commands = vec![
+        ///   Exec::shell("echo tset"),
+        ///   Exec::shell("tr '[:lower:]' '[:upper:]'"),
+        ///   Exec::shell("rev")
+        /// ];
+        ///
+        /// let pipeline = subprocess::Pipeline::from_iter(commands.into_iter());
+        /// let output = pipeline.capture().unwrap().stdout_str();
+        /// assert_eq!(output, "TEST\n");
+        /// ```
         pub fn from_iter<I>(iterator: I) -> Pipeline where I: Iterator<Item = Exec> {
             Pipeline {
                 cmds: iterator.collect(),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -806,7 +806,7 @@ mod pipeline {
         /// a pipeline should be created dynamically.
         ///
         /// Example:
-        /// ```rust
+        /// ```
         /// use subprocess::Exec;
         ///
         /// let commands = vec![
@@ -818,17 +818,26 @@ mod pipeline {
         /// let pipeline = subprocess::Pipeline::from_iter(commands.into_iter());
         /// let output = pipeline.capture().unwrap().stdout_str();
         /// assert_eq!(output, "TEST\n");
-        /// Errors:
-        /// Panics when the passed iterator contains less than two (2)
-        /// items.
         /// ```
+        /// ```should_panic
+        /// use subprocess::Exec;
+        ///
+        /// let commands = vec![
+        ///   Exec::shell("echo tset"),
+        /// ];
+        ///
+        /// // This will panic as there are not enough elements in the iterator.
+        /// let pipeline = subprocess::Pipeline::from_iter(commands.into_iter());
+        /// ```
+        /// Errors:
+        ///   - Panics when the passed iterator contains less than two (2) items.
         pub fn from_iter<I>(iterator: I) -> Pipeline
         where
             I: Iterator<Item = Exec>,
         {
             let cmds: Vec<_> = iterator.collect();
 
-            if cmds.len() >= 2 {
+            if cmds.len() < 2 {
                 panic!("iterator needs to contain at least two (2) elements")
             }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -802,6 +802,17 @@ mod pipeline {
             }
         }
 
+        /// Creates a new pipeline from a list of commands.
+        pub fn from_iter<I>(iterator: I) -> Pipeline where I: Iterator<Item = Exec> {
+            Pipeline {
+                cmds: iterator.collect(),
+                stdin: Redirection::None,
+                stdout: Redirection::None,
+                stderr_file: None,
+                stdin_data: None,
+            }
+        }
+
         /// Specifies how to set up the standard input of the first
         /// command in the pipeline.
         ///

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -828,7 +828,9 @@ mod pipeline {
         {
             let cmds: Vec<_> = iterator.collect();
 
-            assert!(cmds.len() >= 2);
+            if cmds.len() >= 2 {
+                panic!("iterator needs to contain at least two (2) elements")
+            }
 
             Pipeline {
                 cmds,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -815,7 +815,7 @@ mod pipeline {
         ///   Exec::shell("rev")
         /// ];
         ///
-        /// let pipeline = subprocess::Pipeline::from_iter(commands.into_iter());
+        /// let pipeline = subprocess::Pipeline::from_exec_iter(commands);
         /// let output = pipeline.capture().unwrap().stdout_str();
         /// assert_eq!(output, "TEST\n");
         /// ```
@@ -826,16 +826,16 @@ mod pipeline {
         ///   Exec::shell("echo tset"),
         /// ];
         ///
-        /// // This will panic as there are not enough elements in the iterator.
-        /// let pipeline = subprocess::Pipeline::from_iter(commands.into_iter());
+        /// // This will panic as the iterator contains less than two (2) items.
+        /// let pipeline = subprocess::Pipeline::from_exec_iter(commands);
         /// ```
         /// Errors:
         ///   - Panics when the passed iterator contains less than two (2) items.
-        pub fn from_iter<I>(iterator: I) -> Pipeline
+        pub fn from_exec_iter<I>(iterator: I) -> Pipeline
         where
-            I: Iterator<Item = Exec>,
+            I: IntoIterator<Item = Exec>,
         {
-            let cmds: Vec<_> = iterator.collect();
+            let cmds: Vec<_> = iterator.into_iter().collect();
 
             if cmds.len() < 2 {
                 panic!("iterator needs to contain at least two (2) elements")

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -818,10 +818,20 @@ mod pipeline {
         /// let pipeline = subprocess::Pipeline::from_iter(commands.into_iter());
         /// let output = pipeline.capture().unwrap().stdout_str();
         /// assert_eq!(output, "TEST\n");
+        /// Errors:
+        /// Panics when the passed iterator contains less than two (2)
+        /// items.
         /// ```
-        pub fn from_iter<I>(iterator: I) -> Pipeline where I: Iterator<Item = Exec> {
+        pub fn from_iter<I>(iterator: I) -> Pipeline
+        where
+            I: Iterator<Item = Exec>,
+        {
+            let cmds: Vec<_> = iterator.collect();
+
+            assert!(cmds.len() >= 2);
+
             Pipeline {
-                cmds: iterator.collect(),
+                cmds,
                 stdin: Redirection::None,
                 stdout: Redirection::None,
                 stderr_file: None,


### PR DESCRIPTION
Reimplentation of https://github.com/hniksic/rust-subprocess/pull/34 which allows to pass a iterator instead of a vector.