### PR TITLE
Modernize crate

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -10,12 +10,8 @@ mod os {
     pub const SHELL: [&str; 2] = ["cmd.exe", "/c"];
 }
 
-pub use self::exec::{CaptureData, Exec, NullFile};
-pub use self::os::*;
-pub use self::pipeline::Pipeline;
-
-#[cfg(unix)]
-pub use exec::unix;
+pub use exec::{CaptureData, Exec, NullFile};
+pub use pipeline::Pipeline;
 
 mod exec {
     use std::borrow::Cow;
@@ -121,7 +117,6 @@ mod exec {
     ///
     /// [`Popen`]: struct.Popen.html
     /// [`Popen::create`]: struct.Popen.html#method.create
-
     #[must_use]
     pub struct Exec {
         command: OsString,
@@ -257,7 +252,7 @@ mod exec {
                 .env
                 .as_mut()
                 .unwrap()
-                .retain(|&(ref k, ref _v)| k != key.as_ref());
+                .retain(|(k, _v)| k != key.as_ref());
             self
         }
 
@@ -484,7 +479,7 @@ mod exec {
                 let current: Vec<_> = env::vars_os().collect();
                 let current_map: HashMap<_, _> = current.iter().map(|(x, y)| (x, y)).collect();
                 for (k, v) in cmd_env {
-                    if current_map.get(&k) == Some(&&v) {
+                    if current_map.get(&k) == Some(&v) {
                         continue;
                     }
                     out.push_str(&Exec::display_escape(&k.to_string_lossy()));
@@ -700,28 +695,6 @@ mod exec {
             OutputRedirection(Redirection::File(null_file))
         }
     }
-
-    #[cfg(unix)]
-    pub mod unix {
-        use super::Exec;
-
-        pub trait ExecExt {
-            fn setuid(self, uid: u32) -> Self;
-            fn setgid(self, gid: u32) -> Self;
-        }
-
-        impl ExecExt for Exec {
-            fn setuid(mut self, uid: u32) -> Exec {
-                self.config.setuid = Some(uid);
-                self
-            }
-
-            fn setgid(mut self, gid: u32) -> Exec {
-                self.config.setgid = Some(gid);
-                self
-            }
-        }
-    }
 }
 
 mod pipeline {
@@ -779,7 +752,6 @@ mod pipeline {
     /// [`Popen`]: struct.Popen.html
     /// [`Exec`]: struct.Exec.html
     /// [`Pipeline`]: struct.Pipeline.html
-
     #[must_use]
     pub struct Pipeline {
         cmds: Vec<Exec>,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -240,9 +240,10 @@ mod exec {
             self.ensure_env();
             {
                 let envvec = self.config.env.as_mut().unwrap();
-                for &(ref k, ref v) in vars {
-                    envvec.push((k.as_ref().to_owned(), v.as_ref().to_owned()));
-                }
+                envvec.extend(
+                    vars.iter()
+                        .map(|(k, v)| (k.as_ref().to_owned(), v.as_ref().to_owned())),
+                );
             }
             self
         }

--- a/src/communicate.rs
+++ b/src/communicate.rs
@@ -12,7 +12,7 @@ mod raw {
     use std::io::{self, Read, Write};
     use std::time::{Duration, Instant};
 
-    fn as_pollfd<'a>(f: Option<&'a File>, for_read: bool) -> posix::PollFd<'a> {
+    fn as_pollfd(f: Option<&File>, for_read: bool) -> posix::PollFd<'_> {
         let events = if for_read {
             posix::POLLIN
         } else {
@@ -79,7 +79,7 @@ mod raw {
             stderr: Option<File>,
             input_data: Option<Vec<u8>>,
         ) -> RawCommunicator {
-            let input_data = input_data.unwrap_or_else(Vec::new);
+            let input_data = input_data.unwrap_or_default();
             RawCommunicator {
                 stdin,
                 stdout,
@@ -489,13 +489,12 @@ impl Communicator {
     /// # Errors
     ///
     /// * `Err(CommunicateError)` if a system call fails.  In case of timeout,
-    /// the underlying error kind will be `ErrorKind::TimedOut`.
+    ///   the underlying error kind will be `ErrorKind::TimedOut`.
     ///
     /// Regardless of the nature of the error, the content prior to the error
     /// can be retrieved using the [`capture`] attribute of the error.
     ///
     /// [`capture`]: struct.CommunicateError.html#structfield.capture
-
     pub fn read(&mut self) -> Result<(Option<Vec<u8>>, Option<Vec<u8>>), CommunicateError> {
         let deadline = self.time_limit.map(|timeout| Instant::now() + timeout);
         match self.inner.read(deadline, self.size_limit) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,10 +87,10 @@ mod win32;
 
 mod os_common;
 
-pub use self::builder::{CaptureData, Exec, NullFile, Pipeline};
-pub use self::communicate::{CommunicateError, Communicator};
-pub use self::os_common::ExitStatus;
-pub use self::popen::{make_pipe, Popen, PopenConfig, PopenError, Redirection, Result};
+pub use builder::{CaptureData, Exec, NullFile, Pipeline};
+pub use communicate::{CommunicateError, Communicator};
+pub use os_common::ExitStatus;
+pub use popen::{make_pipe, Popen, PopenConfig, PopenError, Redirection, Result};
 
 /// Subprocess extensions for Unix platforms.
 pub mod unix {

--- a/src/popen.rs
+++ b/src/popen.rs
@@ -12,11 +12,11 @@ use std::time::Duration;
 use crate::communicate;
 use crate::os_common::{ExitStatus, StandardStream};
 
-use self::ChildState::*;
+use ChildState::*;
 
-pub use self::os::ext as os_ext;
-pub use self::os::make_pipe;
 pub use communicate::Communicator;
+pub use os::ext as os_ext;
+pub use os::make_pipe;
 
 /// Interface to a running subprocess.
 ///
@@ -302,7 +302,7 @@ impl Redirection {
             Redirection::Pipe => Redirection::Pipe,
             Redirection::Merge => Redirection::Merge,
             Redirection::File(ref f) => Redirection::File(f.try_clone()?),
-            Redirection::RcFile(ref f) => Redirection::RcFile(Rc::clone(&f)),
+            Redirection::RcFile(ref f) => Redirection::RcFile(Rc::clone(f)),
         })
     }
 }
@@ -1270,7 +1270,7 @@ use crate::win32::make_standard_stream;
 fn get_standard_stream(which: StandardStream) -> io::Result<Rc<File>> {
     STREAMS.with(|streams| {
         if let Some(ref stream) = streams.borrow()[which as usize] {
-            return Ok(Rc::clone(&stream));
+            return Ok(Rc::clone(stream));
         }
         let stream = make_standard_stream(which)?;
         streams.borrow_mut()[which as usize] = Some(Rc::clone(&stream));

--- a/src/tests/posix.rs
+++ b/src/tests/posix.rs
@@ -3,8 +3,6 @@ use std::ffi::OsString;
 use crate::unix::PopenExt;
 use crate::{ExitStatus, Popen, PopenConfig, Redirection};
 
-use libc;
-
 #[test]
 fn err_terminate() {
     let mut p = Popen::create(&["sleep", "5"], PopenConfig::default()).unwrap();

--- a/tests/just-echo.rs
+++ b/tests/just-echo.rs
@@ -1,3 +1,3 @@
 fn main() {
-    print!("{}", ::std::env::args().skip(1).next().unwrap());
+    print!("{}", ::std::env::args().nth(1).unwrap());
 }


### PR DESCRIPTION
These are just some suggestions:

- commit 1 uses a modern approach to adding more than one environment variable at once which is more idiomatic with respect to iterator usage in rust. The same code was already used in the `.args` method of the same struct, so this also brings everything more in line
- commit 2 just goes through all the `clippy` lints as of `rust 1.84` and fixes them. Most of them were automatic fixes and I just applied the suggestions from clippy directly

If you want only one of the commits or neither that's fine. In any case I'll adapt the PR to your needs (or close it if those changes are not wanted).