### PR TITLE
Add Windows process creation flags support

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -17,6 +17,12 @@ pub use exec::windows::ExecExt;
 pub use exec::{CaptureData, Exec, NullFile};
 pub use pipeline::Pipeline;
 
+/// Windows-specific process creation constants and extensions.
+#[cfg(windows)]
+pub mod windows {
+    pub use super::exec::windows::*;
+}
+
 mod exec {
     use std::borrow::Cow;
     use std::collections::HashMap;
@@ -705,6 +711,29 @@ mod exec {
     pub mod windows {
         use super::Exec;
 
+        /// Process creation flag: The process does not have a console window.
+        ///
+        /// Use this flag when launching GUI applications or background processes to prevent
+        /// a console window from briefly appearing.
+        pub const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+        /// Process creation flag: The new process has a new console.
+        ///
+        /// This flag cannot be used with `DETACHED_PROCESS`.
+        pub const CREATE_NEW_CONSOLE: u32 = 0x00000010;
+
+        /// Process creation flag: The new process is the root of a new process group.
+        ///
+        /// The process group includes all descendant processes. Useful for sending signals
+        /// to a group of related processes.
+        pub const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
+
+        /// Process creation flag: The process does not inherit its parent's console.
+        ///
+        /// The new process can call `AllocConsole` later to create a console.
+        /// This flag cannot be used with `CREATE_NEW_CONSOLE`.
+        pub const DETACHED_PROCESS: u32 = 0x00000008;
+
         /// Extension trait for Windows-specific process creation options.
         pub trait ExecExt {
             /// Set process creation flags for Windows.
@@ -716,9 +745,8 @@ mod exec {
             /// # Example
             ///
             /// ```ignore
-            /// use subprocess::{Exec, ExecExt};
+            /// use subprocess::{Exec, ExecExt, windows::CREATE_NO_WINDOW};
             ///
-            /// const CREATE_NO_WINDOW: u32 = 0x08000000;
             /// let popen = Exec::cmd("my_app")
             ///     .creation_flags(CREATE_NO_WINDOW)
             ///     .popen()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,12 @@ pub mod unix {
     pub use super::popen::os_ext::*;
 }
 
+/// Subprocess extensions for Windows platforms.
+#[cfg(windows)]
+pub mod windows {
+    pub use super::builder::windows::*;
+}
+
 #[cfg(test)]
 mod tests {
     mod builder;

--- a/src/popen.rs
+++ b/src/popen.rs
@@ -119,15 +119,17 @@ pub struct PopenConfig {
     /// or background process:
     ///
     /// ```ignore
-    /// const CREATE_NO_WINDOW: u32 = 0x08000000;
+    /// use subprocess::{Popen, PopenConfig, windows::CREATE_NO_WINDOW};
+    ///
     /// let popen = Popen::create(&["my_app"], PopenConfig {
     ///     creation_flags: CREATE_NO_WINDOW,
     ///     ..Default::default()
     /// })?;
     /// ```
     ///
-    /// Common flags include `CREATE_NO_WINDOW` (0x08000000), `CREATE_NEW_CONSOLE` (0x00000010),
-    /// and `CREATE_NEW_PROCESS_GROUP` (0x00000200).  See Windows documentation for the full list.
+    /// Available flags are in the [`windows`](crate::windows) module: `CREATE_NO_WINDOW`,
+    /// `CREATE_NEW_CONSOLE`, `CREATE_NEW_PROCESS_GROUP`, `DETACHED_PROCESS`.
+    /// See Windows documentation for the full list.
     #[cfg(windows)]
     pub creation_flags: u32,
 


### PR DESCRIPTION
## Summary

- Add `creation_flags` field to `PopenConfig` for Windows, passed to `CreateProcessW`'s `dwCreationFlags` parameter
- Add `ExecExt` trait for Windows with `creation_flags()` builder method
- Comprehensive documentation with link to Windows docs and usage examples

This allows controlling Windows process creation behavior, such as preventing console windows from appearing when spawning GUI applications or background processes.

## Example

```rust
use subprocess::{Exec, ExecExt, PopenConfig};

const CREATE_NO_WINDOW: u32 = 0x08000000;

// Using Exec builder
let popen = Exec::cmd("my_app")
    .creation_flags(CREATE_NO_WINDOW)
    .popen()?;

// Using PopenConfig directly
let popen = Popen::create(&["my_app"], PopenConfig {
    creation_flags: CREATE_NO_WINDOW,
    ..Default::default()
})?;
```

## Based on

Original PR #52 by @Enrico204, rebased on current master with improvements.

## Test plan

- [x] Builds on Unix (creation_flags field is `#[cfg(windows)]`)
- [x] CI passes on all platforms