### PR TITLE
Reap the child when exec fails

### DIFF
--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -369,10 +369,16 @@ pub(crate) mod os {
         drop(child_ends);
 
         drop(exec_fail_pipe.1);
+        // The fork happened before we could learn that exec would fail, so the child exists
+        // either way and has to be waited for. Construct the Process before reading the pipe
+        // so the failure path owns the pid instead of abandoning it as a zombie. The wait
+        // error, if any, is discarded to report the more useful exec errno.
+        let process = Process::new(pid, (), detached);
         match read_exact_or_eof::<4>(&mut exec_fail_pipe.0)? {
-            None => Ok(Process::new(pid, (), detached)),
+            None => Ok(process),
             Some(error_buf) => {
                 let error_code = u32::from_le_bytes(error_buf);
+                let _ = process.wait();
                 Err(io::Error::from_raw_os_error(error_code as i32))
             }
         }

--- a/src/tests/posix.rs
+++ b/src/tests/posix.rs
@@ -53,6 +53,28 @@ fn run_isolated(name: &str, body: impl FnOnce()) {
 }
 
 #[test]
+fn failed_exec_reaps_child() {
+    // os_start() forks before it can know that exec will fail, so a parent that returns the
+    // error without waiting leaves the child behind as a zombie for the process's lifetime.
+    // Isolated so waitpid(-1) cannot observe a child belonging to a concurrent test.
+    run_isolated("failed_exec_reaps_child", || {
+        assert!(
+            Exec::cmd("/nonexistent/subprocess-exec-failure")
+                .capture()
+                .is_err()
+        );
+
+        let mut status = 0;
+        let reaped = unsafe { libc::waitpid(-1, &mut status, libc::WNOHANG) };
+        assert_eq!(reaped, -1, "exec failure left child {reaped} unreaped");
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ECHILD)
+        );
+    });
+}
+
+#[test]
 fn err_terminate() {
     let job = Exec::cmd("sleep").arg("5").start().unwrap();
     exec_signal_delay();


### PR DESCRIPTION
`os_start()` forks before it can know whether exec will succeed. On failure the child reports its errno over `exec_fail_pipe` and exits 127, but the parent returns the error without ever constructing a `Process` for the pid, so nothing waits on it and the child is left as a zombie for the parent's lifetime.

Callers that probe for optional binaries see this as steady growth of the PID table: one zombie per probe, never reclaimed until the process exits. The success path is unaffected, since it returns a `Process` whose drop waits — so in a mixed workload only the failing spawns accumulate.

The fix constructs the `Process` before reading the pipe, so the failure path owns the pid and waits on it. The wait error is discarded to report the more useful exec errno.

The regression test reuses the existing `run_isolated()` helper, which re-execs the test body in a fresh single-test child process. That makes `waitpid(-1, WNOHANG)` deterministic — no concurrent test's children can be observed — so it can assert the strong property (no child at all, `ECHILD`) rather than inspecting `/proc`. It fails on `master` and passes with the fix; full suite 202/202, clippy `-D warnings` and rustfmt clean.

Note this is distinct from #70, which was about zombies on the success path before `Process` drop waited, and was closed for inactivity.
