### PR TITLE
Round timeouts up to the next millisecond

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ mod job;
 mod pipeline;
 mod process;
 mod spawn;
+mod util;
 
 #[cfg(unix)]
 mod posix;

--- a/src/posix.rs
+++ b/src/posix.rs
@@ -445,7 +445,7 @@ pub fn poll(fds: &mut [PollFd<'_>], mut timeout: Option<Duration>) -> Result<usi
     loop {
         let (timeout_ms, overflow) = timeout
             .map(|timeout| {
-                let timeout = timeout.as_millis();
+                let timeout = crate::util::duration_to_ms_ceil(timeout);
                 if timeout <= i32::MAX as u128 {
                     (timeout as i32, false)
                 } else {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,8 @@
+use std::time::Duration;
+
+/// Converts a timeout to whole milliseconds, rounding up so that a timed wait never
+/// waits less than requested. In particular, a sub-millisecond timeout must not
+/// degenerate into a non-blocking check (timeout of 0).
+pub(crate) fn duration_to_ms_ceil(timeout: Duration) -> u128 {
+    timeout.as_nanos().div_ceil(1_000_000)
+}

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -415,6 +415,23 @@ pub enum WaitResult {
     Timeout,
 }
 
+/// Converts an optional timeout to the millisecond argument of the wait functions,
+/// clamping values that don't fit below INFINITE. The second element of the returned
+/// pair indicates that clamping took place and the wait has to be repeated if it times
+/// out before the caller's deadline.
+fn wait_timeout_to_ms(timeout: Option<Duration>) -> (u32, bool) {
+    timeout
+        .map(|timeout| {
+            let timeout = crate::util::duration_to_ms_ceil(timeout);
+            if timeout < INFINITE as u128 {
+                (timeout as u32, false)
+            } else {
+                (INFINITE - 1, true)
+            }
+        })
+        .unwrap_or((INFINITE, false))
+}
+
 /// Wait for multiple objects, returns the index of the first signaled object.
 pub fn WaitForMultipleObjects(
     handles: &[RawHandle],
@@ -429,16 +446,7 @@ pub fn WaitForMultipleObjects(
     let deadline = timeout.map(|t| Instant::now() + t);
 
     loop {
-        let (timeout_ms, overflow) = remaining_timeout
-            .map(|timeout| {
-                let timeout = timeout.as_millis();
-                if timeout < INFINITE as u128 {
-                    (timeout as u32, false)
-                } else {
-                    (INFINITE - 1, true)
-                }
-            })
-            .unwrap_or((INFINITE, false));
+        let (timeout_ms, overflow) = wait_timeout_to_ms(remaining_timeout);
 
         let result = unsafe {
             synchapi::WaitForMultipleObjects(
@@ -571,16 +579,7 @@ pub fn WaitForSingleObject(handle: &Handle, mut timeout: Option<Duration>) -> Re
     let result = loop {
         // Allow timeouts greater than 50 days by clamping the timeout and sleeping in a
         // loop.
-        let (timeout_ms, overflow) = timeout
-            .map(|timeout| {
-                let timeout = timeout.as_millis();
-                if timeout < INFINITE as u128 {
-                    (timeout as u32, false)
-                } else {
-                    (INFINITE - 1, true)
-                }
-            })
-            .unwrap_or((INFINITE, false));
+        let (timeout_ms, overflow) = wait_timeout_to_ms(timeout);
 
         let result = unsafe { synchapi::WaitForSingleObject(handle.as_raw_handle(), timeout_ms) };
         if result != WAIT_TIMEOUT || !overflow {


### PR DESCRIPTION
When converting Duration to milliseconds for poll() and the Windows wait functions, round up instead of truncating, so a timed wait never waits less than requested. In particular, sub-millisecond timeouts no longer degenerate into a non-blocking check, which could turn caller deadline loops into busy loops.