### PR TITLE
Locate the argv-echo helper without assuming target dir layout

### DIFF
--- a/src/tests/posix.rs
+++ b/src/tests/posix.rs
@@ -279,10 +279,15 @@ fn pre_exec_multiple() {
 // --- arg0 tests ---
 
 fn argv_echo_path() -> std::path::PathBuf {
-    // For unit tests, current_exe() is target/<profile>/deps/<crate>-<hash>;
-    // the argv-echo helper binary sits one level up at target/<profile>/.
+    // Cargo doesn't provide CARGO_BIN_EXE_* to unit tests, and the location of the
+    // test executable relative to target/<profile>/ varies with the cargo version and
+    // target dir layout. Walk up from the test executable until we reach the directory
+    // that holds the argv-echo helper.
     let exe = std::env::current_exe().expect("current_exe");
-    exe.parent().unwrap().parent().unwrap().join("argv-echo")
+    exe.ancestors()
+        .map(|dir| dir.join("argv-echo"))
+        .find(|path| path.exists())
+        .expect("argv-echo helper not found near test executable")
 }
 
 #[test]

--- a/tests/escape-args.rs
+++ b/tests/escape-args.rs
@@ -1,17 +1,12 @@
 extern crate subprocess;
 
 use std::io::Read;
-use std::path::PathBuf;
 use subprocess::{Exec, Redirection};
 
-fn argv_echo_path() -> String {
-    let prog = PathBuf::from(&::std::env::args().next().unwrap());
-    prog.parent()
-        .unwrap()
-        .join("../argv-echo")
-        .to_str()
-        .unwrap()
-        .to_owned()
+fn argv_echo_path() -> &'static str {
+    // Provided by cargo when building integration tests; doesn't depend on the target
+    // dir layout.
+    env!("CARGO_BIN_EXE_argv-echo")
 }
 
 #[test]

--- a/tests/weird-args.rs
+++ b/tests/weird-args.rs
@@ -1,14 +1,12 @@
 extern crate subprocess;
 
 use std::io::Read;
-use std::path::Path;
 use subprocess::{Exec, Redirection};
 
-fn argv_echo_path() -> String {
-    let prog = Path::new(&::std::env::args().next().unwrap()).to_owned();
-    let prog = prog.parent().unwrap(); // dirname
-    let prog = prog.parent().unwrap(); // parent dir
-    prog.join("argv-echo").to_str().unwrap().to_owned()
+fn argv_echo_path() -> &'static str {
+    // Provided by cargo when building integration tests; doesn't depend on the target
+    // dir layout.
+    env!("CARGO_BIN_EXE_argv-echo")
 }
 
 #[test]


### PR DESCRIPTION
Nightly cargo moved test executables out of target/<profile>/deps, which broke tests that found the helper binary by fixed path math relative to the test executable. Integration tests now use the CARGO_BIN_EXE_ env var provided by cargo; the unit test, which doesn't get that var, walks up from the test executable until it finds the helper.